### PR TITLE
优化启动流程

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,7 +38,9 @@ app.set('view engine', 'html');
 app.engine('html', require('ejs').__express);
 
 app.use(bodyParser.json());
-app.use(bodyParser.urlencoded());
+app.use(bodyParser.urlencoded({
+	extnded: true
+}));
 app.use(session({
 	secret: 'lxc',
 	keys: ['user']

--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ app.engine('html', require('ejs').__express);
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({
-	extnded: true
+	extended: true
 }));
 app.use(session({
 	secret: 'lxc',

--- a/bower.json
+++ b/bower.json
@@ -20,5 +20,8 @@
     "angular-cookies": "~1.3.13",
     "ng-file-upload": "~3.0.7",
     "me-pageloading": "~0.4.0"
+  },
+  "resolutions": {
+    "angular": "1.3.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "graduation-project",
   "version": "0.0.0",
   "scripts": {
+    "prestart": "npm install",
+    "postinstall": "bower install",
     "start": "node app.js",
     "coding": "nodemon"
   },
@@ -29,6 +31,7 @@
     "gulp-uglify": "^1.0.2",
     "mongoose": "^3.8.23",
     "multer": "^0.1.8",
-    "nodemon": "^1.2.1"
+    "nodemon": "^1.2.1",
+    "bower": "^1.3.2"
   }
 }


### PR DESCRIPTION
1. 修复启动时bodyparser的warning
2. `npm start`之前自动安装所有的依赖，也就是说，以后项目clone下来后只要运行`npm start`就行了
